### PR TITLE
Make contributing easier with WYSIWYG editor

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -36,15 +36,17 @@ const config = {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl:
-            'https://github.com/teasiu/doc/blob/main/',
+          editUrl: ({ docPath }) => {
+            return `https://holocron.so/github/pr/teasiu/doc/main/editor/docs/${docPath}`
+          },
         },
         blog: {
           showReadingTime: true,
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl:
-            'https://github.com/teasiu/doc/blob/main/',
+          editUrl: ({ docPath }) => {
+            return `https://holocron.so/github/pr/teasiu/doc/main/editor/blog/${docPath}`
+          },
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
After this PR is merged, users will be able to edit pages with the [Holocron](https://holocron.so) markdown editor.

[This](https://holocron.so/github/pr/teasiu/doc/main/editor) is how the editor looks like for your repo.

Users can suggest edits to your docs without leaving the browser, and you can review and merge them with one click.

https://github.com/remorses/docusaurus-example/assets/31321188/43c8bc68-3668-4a25-bf1c-a70eceab7bcb